### PR TITLE
세션 브라우저 그룹 전체 선택 방지 및 성능 개선

### DIFF
--- a/app/schemas/session_record.py
+++ b/app/schemas/session_record.py
@@ -37,6 +37,7 @@ class SessionRecord(SessionRecordBase, TimestampModel):
 
 class CollectRequest(BaseModel):
     proxy_ids: List[int] = Field(min_length=1)
+    defer_save: bool | None = False
 
 
 class CollectResponse(BaseModel):
@@ -45,4 +46,5 @@ class CollectResponse(BaseModel):
     failed: int
     errors: Dict[int, str] = Field(default_factory=dict)
     items: List[SessionRecord]
+    rows: List[List[str]] = Field(default_factory=list)
 

--- a/app/templates/components/session_browser.html
+++ b/app/templates/components/session_browser.html
@@ -53,6 +53,7 @@
                 <div class="level-item">
                     <div class="buttons">
                         <button class="button is-primary" id="sbLoadBtn">세션 불러오기</button>
+                        <label class="checkbox ml-3"><input type="checkbox" id="sbDeferSave"> DB 저장 지연</label>
                         <span id="sbStatus" class="tag is-light ml-2">대기</span>
                     </div>
                 </div>


### PR DESCRIPTION
Disable group-wide selection and add a 'defer DB save' option in the session browser to prevent excessive data collection and improve UI responsiveness by immediately displaying collected data.

---
<a href="https://cursor.com/background-agent?bcId=bc-24de19bf-5dd8-4bbf-aef1-5e589ee2b929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24de19bf-5dd8-4bbf-aef1-5e589ee2b929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

