### PR TITLE
Fix session browser initial group selection bug

### DIFF
--- a/app/static/js/device_selector.js
+++ b/app/static/js/device_selector.js
@@ -106,20 +106,20 @@
 						populateProxies();
 						// Auto-select all proxies in the currently filtered group
 						var allVals = $proxy.find('option').map(function() { return $(this).val(); }).get();
-						try {
-							if (state.ts) { state.ts.setValue(allVals, true); }
-							else { $proxy.find('option').prop('selected', true); $proxy.trigger('change'); }
-						} catch (e) { /* ignore */ }
+					try {
+						if (state.ts) { state.ts.setValue(allVals, false); }
+						else { $proxy.find('option').prop('selected', true); $proxy.trigger('change'); }
+					} catch (e) { /* ignore */ }
 					});
 				}
 				if ($selectAll && $selectAll.length) {
 					$selectAll.off('.devicesel').on('change.devicesel', function() {
 						var checked = $(this).is(':checked');
 						var vals = $proxy.find('option').map(function() { return $(this).val(); }).get();
-						try {
-							if (state.ts) { state.ts.setValue(checked ? vals : [], true); }
-							else { $proxy.find('option').prop('selected', checked); $proxy.trigger('change'); }
-						} catch (e) { /* ignore */ }
+					try {
+						if (state.ts) { state.ts.setValue(checked ? vals : [], false); }
+						else { $proxy.find('option').prop('selected', checked); $proxy.trigger('change'); }
+					} catch (e) { /* ignore */ }
 					});
 				}
 			}
@@ -133,10 +133,10 @@
 				bindEvents(); 
 				if (!allowAllGroups) {
 					var currentVal = $group && $group.length ? $group.val() : '';
-					if (!currentVal) {
+						if (!currentVal) {
 						var first = (state.groups && state.groups.length) ? String(state.groups[0].id) : '';
 						if (first) {
-							try { if (state.gts) { state.gts.setValue(first, true); } else { $group.val(first).trigger('change'); } } catch (e) { /* ignore */ }
+								try { if (state.gts) { state.gts.setValue(first, false); } else { $group.val(first).trigger('change'); } } catch (e) { /* ignore */ }
 						}
 					}
 				}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Tom Select `setValue` calls to not be silent, fixing a bug where initial group selection and "select all" actions didn't trigger change events.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The bug occurred because `Tom Select`'s `setValue` method was called with the `silent` flag set to `true`. This prevented the necessary `change` events from firing, causing the UI to appear updated (e.g., the first group looked selected) but the actual selection state and downstream logic remained unapplied until a manual interaction triggered a non-silent change. By setting `silent` to `false`, the change events are now correctly dispatched, ensuring immediate and accurate reflection of the selection state.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e979d37-871b-463a-a56d-ed931584e501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e979d37-871b-463a-a56d-ed931584e501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

