### PR TITLE
Allow copying hostnames from chart details

### DIFF
--- a/app/templates/components/traffic_logs.html
+++ b/app/templates/components/traffic_logs.html
@@ -131,6 +131,7 @@
 	</div>
 
 	<div id="tlaCharts" style="display:none;">
+		<p class="mb-2 has-text-grey is-size-7">차트 막대를 클릭하면 해당 항목 라벨(예: 호스트명/클라이언트 IP/URL)을 복사합니다.</p>
 		<div class="columns">
 			<div class="column is-6"><div class="box"><h5 class="title is-6">요청 상위 클라이언트</h5><div id="tlaChartClientReq"></div></div></div>
 			<div class="column is-6"><div class="box"><h5 class="title is-6">요청 상위 호스트</h5><div id="tlaChartHosts"></div></div></div>


### PR DESCRIPTION
Add click-to-copy functionality to traffic log analysis chart bars and a help text to enable copying of labels like hostnames.

---
<a href="https://cursor.com/background-agent?bcId=bc-afedbf46-d159-4d20-b70e-44588779a830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afedbf46-d159-4d20-b70e-44588779a830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

