### PR TITLE
feat: increase session browser table height

### DIFF
--- a/app/static/js/table_config.js
+++ b/app/static/js/table_config.js
@@ -32,7 +32,7 @@
 		info: true,
 		responsive: false,
 		scrollX: true,
-		scrollY: 480,
+		scrollY: 800,
 		scrollCollapse: true,
 		orderCellsTop: true,
 		pageLength: 25,


### PR DESCRIPTION
Increases the default height of the DataTables used in the application from 480px to 800px to provide more vertical space for the session browser table.