### PR TITLE
Fix: Correctly Display Session Analysis Metadata

### DIFF
--- a/app/api/session_browser.py
+++ b/app/api/session_browser.py
@@ -677,6 +677,9 @@ async def sessions_analyze(
     # Load latest batches
     rows: List[Dict[str, Any]] = _load_latest_rows_for_proxies(db, target_ids)
 
+    # Get unique hostnames from the loaded rows
+    target_hosts = sorted(list(set([row.get("host") for row in rows if row.get("host")])))
+
     # Aggregations
     from collections import Counter, defaultdict
 
@@ -771,6 +774,8 @@ async def sessions_analyze(
 
     # Build top sections with data-centric keys; keep old keys for backward compatibility
     result = {
+        "analyzed_at": now_kst().isoformat(),
+        "target_hosts": target_hosts,
         "summary": {
             "total_sessions": len(rows),
             "unique_clients": len(unique_clients),

--- a/app/static/js/session_browser_analyze.js
+++ b/app/static/js/session_browser_analyze.js
@@ -46,7 +46,15 @@
 		return { categories, data };
 	}
 
-	function renderSummary(summary){
+	function renderSummary(payload){
+		const summary = payload.summary || {};
+		const hosts = payload.target_hosts || [];
+
+		// New fields for analysis metadata
+		$('#sbAnalyzedAt').text(payload.analyzed_at ? fmtDt(payload.analyzed_at) : '-');
+		$('#sbTargetHosts').text(hosts.length > 0 ? hosts.join(', ') : '-');
+
+		// Existing summary fields
 		$('#sbTotSessions').text(summary.total_sessions || 0);
 		$('#sbClients').text(summary.unique_clients || 0);
 		$('#sbHosts').text(summary.unique_hosts || 0);
@@ -82,7 +90,7 @@
 			if(!raw) return;
 			const data = JSON.parse(raw);
 			if(!data || typeof data !== 'object') return;
-			renderSummary(data.summary || {});
+			renderSummary(data); // Pass the full object
 			renderCharts(data);
 			setStatus('저장된 분석 결과', 'is-light');
 			$('#sbAnalyzeSection').show();
@@ -100,7 +108,7 @@
 			const res = await fetch(`${API_BASE}/session-browser/analyze?${qs}`);
 			if(!res.ok){ const err = await res.json().catch(()=>({detail:'분석 실패'})); throw new Error(err.detail || '분석 실패'); }
 			const data = await res.json();
-			renderSummary(data.summary || {});
+			renderSummary(data); // Pass the full object
 			renderCharts(data);
 			saveResult(data);
 			$('#sbAnalyzeSection').show();

--- a/app/templates/components/session_browser.html
+++ b/app/templates/components/session_browser.html
@@ -95,6 +95,22 @@
             <p id="sbAnalyzeError" class="help is-danger" style="display:none;"></p>
 
             <div id="sbSummary" class="columns is-multiline" style="display:none;">
+                <div class="column is-12">
+                    <div class="columns">
+                        <div class="column is-3">
+                            <div class="box has-text-centered" style="height: 100%;">
+                                <p class="heading">분석 시간</p>
+                                <p class="title is-6" id="sbAnalyzedAt">-</p>
+                            </div>
+                        </div>
+                        <div class="column is-9">
+                            <div class="box" style="height: 100%;">
+                                <p class="heading">분석 대상</p>
+                                <p id="sbTargetHosts" class="is-size-7" style="height: 40px; overflow-y: auto;">-</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div class="column is-2"><div class="box has-text-centered"><p class="heading">총 세션</p><p class="title is-5" id="sbTotSessions">0</p></div></div>
                 <div class="column is-2"><div class="box has-text-centered"><p class="heading">클라이언트 수</p><p class="title is-5" id="sbClients">0</p></div></div>
                 <div class="column is-2"><div class="box has-text-centered"><p class="heading">호스트 수</p><p class="title is-5" id="sbHosts">0</p></div></div>


### PR DESCRIPTION
This commit resolves issues from a previous attempt to add analysis metadata to the session browser. The user reported layout problems and empty values, which are addressed herein.

- The HTML layout for the analysis summary has been redesigned to cleanly display the analysis time and target hosts.
- The frontend JavaScript now correctly handles the data payload from both the API and local storage, ensuring that new and old data formats are rendered correctly without leaving fields blank.
- The backend API changes remain the same, providing the necessary `analyzed_at` and `target_hosts` fields.